### PR TITLE
Logout(Basic && Social) API 통합 PR

### DIFF
--- a/src/main/java/com/elice/ustory/domain/user/controller/UserController.java
+++ b/src/main/java/com/elice/ustory/domain/user/controller/UserController.java
@@ -113,7 +113,7 @@ public class UserController {
             naverService.naverLogout(accessToken);
         }
 
-        LogoutResponse logoutResponse = userService.logout(accessToken);
+        LogoutResponse logoutResponse = userService.logout(accessToken, loginType);
         return ResponseEntity.ok().body(logoutResponse);
     }
 

--- a/src/main/java/com/elice/ustory/domain/user/controller/UserController.java
+++ b/src/main/java/com/elice/ustory/domain/user/controller/UserController.java
@@ -39,6 +39,9 @@ public class UserController {
     private final NaverService naverService;
     private final JwtUtil jwtUtil;
 
+    private static final String KAKAO_LOGIN_TYPE = "KAKAO";
+    private static final String NAVER_LOGIN_TYPE = "NAVER";
+
     @Operation(summary = "Create User API", description = "기본 회원가입 후 유저를 생성한다." +
             "<br>비밀번호는 **숫자, 영문, 특수문자 각 1개를 포함한 8~16자** 이며," +
             "<br>보안을 위해, 이때 특수문자는 **~!@#%^*** 만 허용한다.")
@@ -107,9 +110,9 @@ public class UserController {
         String accessToken = jwtUtil.getTokenFromRequest(request);
         String loginType = jwtUtil.getLoginType(accessToken);
 
-        if(loginType.equals("KAKAO")){
+        if(loginType.equals(KAKAO_LOGIN_TYPE)){
             kakaoService.kakaoLogout(accessToken);
-        }else if(loginType.equals("NAVER")){
+        }else if(loginType.equals(NAVER_LOGIN_TYPE)){
             naverService.naverLogout(accessToken);
         }
 

--- a/src/main/java/com/elice/ustory/domain/user/controller/UserController.java
+++ b/src/main/java/com/elice/ustory/domain/user/controller/UserController.java
@@ -8,6 +8,9 @@ import com.elice.ustory.domain.user.service.EmailService;
 import com.elice.ustory.domain.user.service.UserService;
 import com.elice.ustory.global.exception.dto.ErrorResponse;
 import com.elice.ustory.global.jwt.JwtAuthorization;
+import com.elice.ustory.global.jwt.JwtUtil;
+import com.elice.ustory.global.oauth.kakao.KakaoService;
+import com.elice.ustory.global.oauth.naver.NaverService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,6 +35,9 @@ public class UserController {
 
     private final UserService userService;
     private final EmailService emailService;
+    private final KakaoService kakaoService;
+    private final NaverService naverService;
+    private final JwtUtil jwtUtil;
 
     @Operation(summary = "Create User API", description = "기본 회원가입 후 유저를 생성한다." +
             "<br>비밀번호는 **숫자, 영문, 특수문자 각 1개를 포함한 8~16자** 이며," +
@@ -98,7 +104,16 @@ public class UserController {
     })
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logoutBasic(HttpServletRequest request) {
-        LogoutResponse logoutResponse = userService.logout(request);
+        String accessToken = jwtUtil.getTokenFromRequest(request);
+        String loginType = jwtUtil.getLoginType(accessToken);
+
+        if(loginType.equals("KAKAO")){
+            kakaoService.kakaoLogout(accessToken);
+        }else if(loginType.equals("NAVER")){
+            naverService.naverLogout(accessToken);
+        }
+
+        LogoutResponse logoutResponse = userService.logout(accessToken);
         return ResponseEntity.ok().body(logoutResponse);
     }
 

--- a/src/main/java/com/elice/ustory/domain/user/dto/LogoutResponse.java
+++ b/src/main/java/com/elice/ustory/domain/user/dto/LogoutResponse.java
@@ -1,10 +1,16 @@
 package com.elice.ustory.domain.user.dto;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@Data
-@Builder
+@RequiredArgsConstructor
+@Getter
 public class LogoutResponse {
-    Boolean success;
+    private Boolean success;
+    private String loginType;
+
+    public LogoutResponse(Boolean success, String loginType) {
+        this.success = success;
+        this.loginType = loginType;
+    }
 }

--- a/src/main/java/com/elice/ustory/domain/user/service/UserService.java
+++ b/src/main/java/com/elice/ustory/domain/user/service/UserService.java
@@ -14,8 +14,10 @@ import com.elice.ustory.domain.user.entity.Users;
 import com.elice.ustory.domain.user.repository.UserRepository;
 import com.elice.ustory.global.exception.model.*;
 import com.elice.ustory.global.jwt.JwtTokenProvider;
+import com.elice.ustory.global.oauth.kakao.KakaoService;
+import com.elice.ustory.global.oauth.naver.NaverService;
+import com.elice.ustory.global.redis.naver.NaverTokenService;
 import com.elice.ustory.global.redis.refresh.RefreshTokenService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -226,19 +228,8 @@ public class UserService {
         return loginResponse;
     }
 
-    public LogoutResponse logout(HttpServletRequest request) {
-        // 리프레시 토큰 삭제
-        String token = request.getHeader("Authorization");
-
-        if (token == null) {
-            throw new UnauthorizedException(UserMessageConstants.UNAUTHORIZED_MESSAGE);
-        }
-        if (token.startsWith("Bearer ")) {
-            token = token.substring(7);
-        }
-
-        refreshTokenService.removeTokenInfo(token);
-
+    public LogoutResponse logout(String accessToken) {
+        refreshTokenService.removeTokenInfo(accessToken);
         LogoutResponse logoutResponse = LogoutResponse.builder().success(true).build();
         return logoutResponse;
     }

--- a/src/main/java/com/elice/ustory/domain/user/service/UserService.java
+++ b/src/main/java/com/elice/ustory/domain/user/service/UserService.java
@@ -228,10 +228,9 @@ public class UserService {
         return loginResponse;
     }
 
-    public LogoutResponse logout(String accessToken) {
+    public LogoutResponse logout(String accessToken, String loginType) {
         refreshTokenService.removeTokenInfo(accessToken);
-        LogoutResponse logoutResponse = LogoutResponse.builder().success(true).build();
-        return logoutResponse;
+        return new LogoutResponse(true, loginType);
     }
 
     public MyPageResponse showMyPage(Long userId) {

--- a/src/main/java/com/elice/ustory/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtTokenProvider.java
@@ -35,6 +35,7 @@ public class JwtTokenProvider {
         Claims claims = Jwts.claims();
         Date now = new Date();
         claims.put("userId", userId);
+        claims.put("loginType", Users.LoginType.BASIC);
         log.info("[createAccessToken] access 토큰 생성 완료");
         return Jwts.builder()
                 .setClaims(claims)

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -75,6 +75,12 @@ public class JwtUtil {
                 .parseClaimsJws(token).getBody().get("userId").toString());
     }
 
+    public String getLoginType(String token) {
+        log.info("[getLoginType] 현재 로그인 된 유저의 로그인 방식 추출");
+        return Jwts.parserBuilder().setSigningKey(jwtTokenProvider.getSecretKey()).build()
+                .parseClaimsJws(token).getBody().get("loginType").toString();
+    }
+
     public boolean validateToken(String jwtToken) {
         log.info("[validateToken] 토큰 유효 체크 시작 ");
         try {

--- a/src/main/java/com/elice/ustory/global/oauth/kakao/KakaoController.java
+++ b/src/main/java/com/elice/ustory/global/oauth/kakao/KakaoController.java
@@ -1,7 +1,6 @@
 package com.elice.ustory.global.oauth.kakao;
 
 import com.elice.ustory.domain.user.dto.LoginResponse;
-import com.elice.ustory.domain.user.dto.LogoutResponse;
 import com.elice.ustory.domain.user.service.UserService;
 import com.elice.ustory.global.exception.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,14 +9,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -56,17 +52,5 @@ public class KakaoController {
 
         log.info("[kakaoLogin] 카카오 닉네임: {}", nickname);
         return ResponseEntity.ok().body(loginResponse);
-    }
-
-    @Operation(summary = "KAKAO LOGOUT API", description = "카카오 로그아웃")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Ok", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LogoutResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @RequestMapping(value = "/auth/logout/kakao", method = {RequestMethod.GET, RequestMethod.POST})
-    public ResponseEntity<LogoutResponse> kakaoLogout(HttpServletRequest request) {
-        LogoutResponse logoutResponse = kakaoService.kakaoLogout(request);
-        return ResponseEntity.ok().body(logoutResponse);
     }
 }

--- a/src/main/java/com/elice/ustory/global/oauth/kakao/KakaoService.java
+++ b/src/main/java/com/elice/ustory/global/oauth/kakao/KakaoService.java
@@ -8,17 +8,14 @@ import com.elice.ustory.domain.diaryUser.entity.DiaryUser;
 import com.elice.ustory.domain.diaryUser.entity.DiaryUserId;
 import com.elice.ustory.domain.diaryUser.repository.DiaryUserRepository;
 import com.elice.ustory.domain.user.dto.LoginResponse;
-import com.elice.ustory.domain.user.dto.LogoutResponse;
 import com.elice.ustory.domain.user.entity.Users;
 import com.elice.ustory.domain.user.repository.UserRepository;
-import com.elice.ustory.domain.user.service.UserService;
 import com.elice.ustory.global.exception.model.NotFoundException;
 import com.elice.ustory.global.jwt.JwtTokenProvider;
 import com.elice.ustory.global.jwt.JwtUtil;
 import com.elice.ustory.global.redis.kakao.KakaoTokenService;
 import com.elice.ustory.global.redis.refresh.RefreshTokenService;
 import com.elice.ustory.global.util.RandomGenerator;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +36,6 @@ public class KakaoService {
     private final KakaoTokenService kakaoTokenService;
     private final JwtUtil jwtUtil;
     private final KakaoOauth kakaoOauth;
-    private final UserService userService;
     private final RandomGenerator randomGenerator;
     private final PasswordEncoder passwordEncoder;
 
@@ -93,13 +89,9 @@ public class KakaoService {
         return loginResponse;
     }
 
-    public LogoutResponse kakaoLogout(HttpServletRequest request) {
-        String accessToken = jwtUtil.getTokenFromRequest(request);
+    public void kakaoLogout(String accessToken) {
         String kakaoToken = jwtUtil.getSocialToken(accessToken);
         kakaoOauth.expireKakaoToken(kakaoToken);
         kakaoTokenService.removeKakaoTokenInfo(accessToken);
-        userService.logout(request);
-
-        return LogoutResponse.builder().success(true).build();
     }
 }

--- a/src/main/java/com/elice/ustory/global/oauth/naver/NaverController.java
+++ b/src/main/java/com/elice/ustory/global/oauth/naver/NaverController.java
@@ -60,16 +60,4 @@ public class NaverController {
         log.info("[naverLogin] 네이버 닉네임: {}", nickname);
         return ResponseEntity.ok().body(loginResponse);
     }
-
-    @Operation(summary = "NAVER LOGOUT API", description = "네이버 로그아웃")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Ok", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LogoutResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @RequestMapping(value = "/auth/logout/naver", method = {RequestMethod.GET, RequestMethod.POST})
-    public ResponseEntity<LogoutResponse> naverLogout(HttpServletRequest request) {
-        LogoutResponse logoutResponse = naverService.naverLogout(request);
-        return ResponseEntity.ok().body(logoutResponse);
-    }
 }

--- a/src/main/java/com/elice/ustory/global/oauth/naver/NaverService.java
+++ b/src/main/java/com/elice/ustory/global/oauth/naver/NaverService.java
@@ -8,7 +8,6 @@ import com.elice.ustory.domain.diaryUser.entity.DiaryUser;
 import com.elice.ustory.domain.diaryUser.entity.DiaryUserId;
 import com.elice.ustory.domain.diaryUser.repository.DiaryUserRepository;
 import com.elice.ustory.domain.user.dto.LoginResponse;
-import com.elice.ustory.domain.user.dto.LogoutResponse;
 import com.elice.ustory.domain.user.entity.Users;
 import com.elice.ustory.domain.user.repository.UserRepository;
 import com.elice.ustory.domain.user.service.UserService;
@@ -18,7 +17,6 @@ import com.elice.ustory.global.jwt.JwtUtil;
 import com.elice.ustory.global.redis.naver.NaverTokenService;
 import com.elice.ustory.global.redis.refresh.RefreshTokenService;
 import com.elice.ustory.global.util.RandomGenerator;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,11 +32,9 @@ public class NaverService {
     private final UserRepository userRepository;
     private final DiaryRepository diaryRepository;
     private final DiaryUserRepository diaryUserRepository;
-    private final UserService userService;
     private final RefreshTokenService refreshTokenService;
     private final NaverTokenService naverTokenService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final JwtUtil jwtUtil;
     private final RandomGenerator randomGenerator;
     private final PasswordEncoder passwordEncoder;
 
@@ -92,11 +88,7 @@ public class NaverService {
         return loginResponse;
     }
 
-    public LogoutResponse naverLogout(HttpServletRequest request) {
-        String accessToken = jwtUtil.getTokenFromRequest(request);
+    public void naverLogout(String accessToken) {
         naverTokenService.removeNaverTokenInfo(accessToken);
-        userService.logout(request);
-
-        return LogoutResponse.builder().success(true).build();
     }
 }


### PR DESCRIPTION
소통 오류로 인해 로그아웃이 프론트 측에서 로컬 스토리지 내의 토큰만 날리는 것 만으로 
진행되고 있다고 들었습니다(== 로그아웃 API를 사용하고 있지 않음).

그래서 프론트 측에 로그아웃 API 이용하는 방법 알려드렸고, 
일반 로그아웃이랑 소셜 로그아웃 API를 빠르게 하나로 통합 시켰답니다.