### PR TITLE
JWT Refresh 리팩토링 관련 PR

### DIFF
--- a/src/main/java/com/elice/ustory/global/jwt/JwtController.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtController.java
@@ -34,14 +34,14 @@ public class JwtController {
             @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/re-issue")
-    public ResponseEntity<String> reIssueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<JwtRefreshResponse> reIssueAccessToken(HttpServletRequest request, HttpServletResponse response) {
         log.info("[reIssueAccessToken API] AccessToken 재발급 API 시작");
 
-        boolean isRefreshed = jwtUtil.refreshAuthentication(request, response);
+        String refreshedToken = jwtUtil.refreshAuthentication(request, response);
 
-        if (isRefreshed) {
+        if (refreshedToken!= null) {
             log.info("[handleAccessTokenExpiredException] AccessToken 갱신 완료");
-            return ResponseEntity.ok().body(response.getHeader("Authorization"));
+            return ResponseEntity.ok().body(new JwtRefreshResponse(refreshedToken));
         } else {
             log.warn("[handleAccessTokenExpiredException] RefreshToken이 만료되었습니다. 재로그인 필요.");
             throw new RefreshTokenExpiredException("RefreshToken이 만료되었습니다, 재로그인해주세요.");

--- a/src/main/java/com/elice/ustory/global/jwt/JwtController.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtController.java
@@ -39,12 +39,12 @@ public class JwtController {
 
         String refreshedToken = jwtUtil.refreshAuthentication(request, response);
 
-        if (refreshedToken!= null) {
-            log.info("[handleAccessTokenExpiredException] AccessToken 갱신 완료");
-            return ResponseEntity.ok().body(new JwtRefreshResponse(refreshedToken));
-        } else {
+        if (refreshedToken == null) {
             log.warn("[handleAccessTokenExpiredException] RefreshToken이 만료되었습니다. 재로그인 필요.");
             throw new RefreshTokenExpiredException("RefreshToken이 만료되었습니다, 재로그인해주세요.");
         }
+
+        log.info("[handleAccessTokenExpiredException] AccessToken 갱신 완료");
+        return ResponseEntity.ok().body(new JwtRefreshResponse(refreshedToken));
     }
 }

--- a/src/main/java/com/elice/ustory/global/jwt/JwtController.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtController.java
@@ -34,10 +34,10 @@ public class JwtController {
             @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/re-issue")
-    public ResponseEntity<JwtRefreshResponse> reIssueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<JwtRefreshResponse> reIssueAccessToken(HttpServletRequest request) {
         log.info("[reIssueAccessToken API] AccessToken 재발급 API 시작");
 
-        String refreshedToken = jwtUtil.refreshAuthentication(request, response);
+        String refreshedToken = jwtUtil.refreshAuthentication(request);
 
         log.info("[handleAccessTokenExpiredException] AccessToken 갱신 완료");
         return ResponseEntity.ok().body(new JwtRefreshResponse(refreshedToken));

--- a/src/main/java/com/elice/ustory/global/jwt/JwtController.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtController.java
@@ -39,11 +39,6 @@ public class JwtController {
 
         String refreshedToken = jwtUtil.refreshAuthentication(request, response);
 
-        if (refreshedToken == null) {
-            log.warn("[handleAccessTokenExpiredException] RefreshToken이 만료되었습니다. 재로그인 필요.");
-            throw new RefreshTokenExpiredException("RefreshToken이 만료되었습니다, 재로그인해주세요.");
-        }
-
         log.info("[handleAccessTokenExpiredException] AccessToken 갱신 완료");
         return ResponseEntity.ok().body(new JwtRefreshResponse(refreshedToken));
     }

--- a/src/main/java/com/elice/ustory/global/jwt/JwtRefreshResponse.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtRefreshResponse.java
@@ -1,12 +1,10 @@
 package com.elice.ustory.global.jwt;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 @Getter
 public class JwtRefreshResponse {
-    private String refreshAccessToken;
+    private final String refreshAccessToken;
 
     public JwtRefreshResponse(String refreshAccessToken) {
         this.refreshAccessToken = refreshAccessToken;

--- a/src/main/java/com/elice/ustory/global/jwt/JwtRefreshResponse.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtRefreshResponse.java
@@ -1,0 +1,14 @@
+package com.elice.ustory.global.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class JwtRefreshResponse {
+    private String refreshAccessToken;
+
+    public JwtRefreshResponse(String refreshAccessToken) {
+        this.refreshAccessToken = refreshAccessToken;
+    }
+}

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -5,6 +5,8 @@ import com.elice.ustory.domain.user.service.UserService;
 import com.elice.ustory.global.exception.model.InvalidTokenException;
 import com.elice.ustory.global.redis.kakao.KakaoToken;
 import com.elice.ustory.global.redis.kakao.KakaoTokenService;
+import com.elice.ustory.global.redis.naver.NaverToken;
+import com.elice.ustory.global.redis.naver.NaverTokenService;
 import com.elice.ustory.global.redis.refresh.RefreshToken;
 import com.elice.ustory.global.redis.refresh.RefreshTokenService;
 import io.jsonwebtoken.*;
@@ -25,6 +27,7 @@ public class JwtUtil {
     private final UserService userService;
     private final RefreshTokenService refreshTokenService;
     private final KakaoTokenService kakaoTokenService;
+    private final NaverTokenService naverTokenService;
 
     public String refreshAuthentication(HttpServletRequest request, HttpServletResponse response){
         String accessToken = getTokenFromRequest(request);
@@ -47,6 +50,11 @@ public class JwtUtil {
                         .orElseThrow();
 
                 kakaoTokenService.saveKakaoTokenInfo(loginUser.getId(), kakaoToken.getKakaoToken(), newAccessToken);
+            }else if(loginUser.getLoginType().toString().equals("NAVER")){
+                NaverToken naverToken = naverTokenService.getByAccessToken(accessToken)
+                        .orElseThrow();
+
+                naverTokenService.saveNaverTokenInfo(loginUser.getId(), naverToken.getNaverToken(), newAccessToken);
             }
             log.info("[refreshToken] AccessToken이 재발급 되었습니다: {}", newAccessToken);
             log.info("[refreshToken] RefreshToken이 재발급 되었습니다: {}", newRefreshToken);

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -26,7 +26,7 @@ public class JwtUtil {
     private final RefreshTokenService refreshTokenService;
     private final KakaoTokenService kakaoTokenService;
 
-    public boolean refreshAuthentication(HttpServletRequest request, HttpServletResponse response){
+    public String refreshAuthentication(HttpServletRequest request, HttpServletResponse response){
         String accessToken = getTokenFromRequest(request);
         RefreshToken refreshToken = refreshTokenService.getByAccessToken(accessToken)
                 .orElseThrow((() -> new InvalidTokenException("토큰이 없거나 형식에 맞지 않습니다.")));
@@ -51,11 +51,10 @@ public class JwtUtil {
             log.info("[refreshToken] AccessToken이 재발급 되었습니다: {}", newAccessToken);
             log.info("[refreshToken] RefreshToken이 재발급 되었습니다: {}", newRefreshToken);
 
-            response.addHeader("Authorization", newAccessToken);
-            return true;
+            return newAccessToken;
         } else {
             log.warn("[refreshToken] RefreshToken이 만료 되었습니다.");
-            return false;
+            return null;
         }
     }
 

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -3,6 +3,7 @@ package com.elice.ustory.global.jwt;
 import com.elice.ustory.domain.user.entity.Users;
 import com.elice.ustory.domain.user.service.UserService;
 import com.elice.ustory.global.exception.model.InvalidTokenException;
+import com.elice.ustory.global.exception.model.RefreshTokenExpiredException;
 import com.elice.ustory.global.redis.kakao.KakaoToken;
 import com.elice.ustory.global.redis.kakao.KakaoTokenService;
 import com.elice.ustory.global.redis.naver.NaverToken;
@@ -66,7 +67,7 @@ public class JwtUtil {
             return newAccessToken;
         } else {
             log.warn("[refreshToken] RefreshToken이 만료 되었습니다.");
-            return null;
+            throw new RefreshTokenExpiredException("RefreshToken이 만료되었습니다, 재로그인해주세요.");
         }
     }
 

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -33,7 +33,7 @@ public class JwtUtil {
     private static final String NAVER_LOGIN_TYPE = "NAVER";
     private static final String INVALID_TOKEN_MESSAGE = "토큰이 없거나 형식에 맞지 않습니다.";
 
-    public String refreshAuthentication(HttpServletRequest request, HttpServletResponse response){
+    public String refreshAuthentication(HttpServletRequest request, HttpServletResponse response) {
         String accessToken = getTokenFromRequest(request);
         RefreshToken refreshToken = refreshTokenService.getByAccessToken(accessToken)
                 .orElseThrow((() -> new InvalidTokenException(INVALID_TOKEN_MESSAGE)));
@@ -49,12 +49,12 @@ public class JwtUtil {
 
             refreshTokenService.saveTokenInfo(loginUser.getId(), newRefreshToken, newAccessToken, remainingTTL);
 
-            if(loginUser.getLoginType().toString().equals(KAKAO_LOGIN_TYPE)){
+            if (loginUser.getLoginType().toString().equals(KAKAO_LOGIN_TYPE)) {
                 KakaoToken kakaoToken = kakaoTokenService.getByAccessToken(accessToken)
                         .orElseThrow(() -> new InvalidTokenException(INVALID_TOKEN_MESSAGE));
 
                 kakaoTokenService.saveKakaoTokenInfo(loginUser.getId(), kakaoToken.getKakaoToken(), newAccessToken);
-            }else if(loginUser.getLoginType().toString().equals(NAVER_LOGIN_TYPE)){
+            } else if (loginUser.getLoginType().toString().equals(NAVER_LOGIN_TYPE)) {
                 NaverToken naverToken = naverTokenService.getByAccessToken(accessToken)
                         .orElseThrow(() -> new InvalidTokenException(INVALID_TOKEN_MESSAGE));
 
@@ -70,12 +70,12 @@ public class JwtUtil {
         }
     }
 
-    public String getTokenFromRequest(HttpServletRequest request){
+    public String getTokenFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             log.info("이거 베어러 토큰임: {}", bearerToken);
             return bearerToken.substring("Bearer ".length());
-        }else {
+        } else {
             throw new InvalidTokenException(INVALID_TOKEN_MESSAGE);
         }
     }
@@ -117,7 +117,7 @@ public class JwtUtil {
         return Math.max(remainingMillis, 0) / 1000;
     }
 
-    public String getSocialToken(String jwtToken){
+    public String getSocialToken(String jwtToken) {
         Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(jwtTokenProvider.getSecretKey()).build()
                 .parseClaimsJws(jwtToken);
         return claims.getBody().get("socialToken").toString();

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -35,7 +35,7 @@ public class JwtUtil {
     private static final String INVALID_TOKEN_MESSAGE = "토큰이 없거나 형식에 맞지 않습니다.";
     private static final String REFRESH_TOKEN_EXPIRED_MESSAGE = "RefreshToken이 만료되었습니다, 재로그인해주세요.";
 
-    public String refreshAuthentication(HttpServletRequest request, HttpServletResponse response) {
+    public String refreshAuthentication(HttpServletRequest request) {
         String accessToken = getTokenFromRequest(request);
         RefreshToken refreshToken = refreshTokenService.getByAccessToken(accessToken)
                 .orElseThrow((() -> new InvalidTokenException(INVALID_TOKEN_MESSAGE)));

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -33,6 +33,7 @@ public class JwtUtil {
     private static final String KAKAO_LOGIN_TYPE = "KAKAO";
     private static final String NAVER_LOGIN_TYPE = "NAVER";
     private static final String INVALID_TOKEN_MESSAGE = "토큰이 없거나 형식에 맞지 않습니다.";
+    private static final String REFRESH_TOKEN_EXPIRED_MESSAGE = "RefreshToken이 만료되었습니다, 재로그인해주세요.";
 
     public String refreshAuthentication(HttpServletRequest request, HttpServletResponse response) {
         String accessToken = getTokenFromRequest(request);
@@ -67,7 +68,7 @@ public class JwtUtil {
             return newAccessToken;
         } else {
             log.warn("[refreshToken] RefreshToken이 만료 되었습니다.");
-            throw new RefreshTokenExpiredException("RefreshToken이 만료되었습니다, 재로그인해주세요.");
+            throw new RefreshTokenExpiredException(REFRESH_TOKEN_EXPIRED_MESSAGE);
         }
     }
 

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -50,12 +50,12 @@ public class JwtUtil {
 
             if(loginUser.getLoginType().toString().equals(KAKAO_LOGIN_TYPE)){
                 KakaoToken kakaoToken = kakaoTokenService.getByAccessToken(accessToken)
-                        .orElseThrow();
+                        .orElseThrow(() -> new InvalidTokenException("토큰이 없거나 토큰 형식이 잘못되었습니다."));
 
                 kakaoTokenService.saveKakaoTokenInfo(loginUser.getId(), kakaoToken.getKakaoToken(), newAccessToken);
             }else if(loginUser.getLoginType().toString().equals(NAVER_LOGIN_TYPE)){
                 NaverToken naverToken = naverTokenService.getByAccessToken(accessToken)
-                        .orElseThrow();
+                        .orElseThrow(() -> new InvalidTokenException("토큰이 없거나 토큰 형식이 잘못되었습니다."));
 
                 naverTokenService.saveNaverTokenInfo(loginUser.getId(), naverToken.getNaverToken(), newAccessToken);
             }

--- a/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
+++ b/src/main/java/com/elice/ustory/global/jwt/JwtUtil.java
@@ -29,6 +29,9 @@ public class JwtUtil {
     private final KakaoTokenService kakaoTokenService;
     private final NaverTokenService naverTokenService;
 
+    private static final String KAKAO_LOGIN_TYPE = "KAKAO";
+    private static final String NAVER_LOGIN_TYPE = "NAVER";
+
     public String refreshAuthentication(HttpServletRequest request, HttpServletResponse response){
         String accessToken = getTokenFromRequest(request);
         RefreshToken refreshToken = refreshTokenService.getByAccessToken(accessToken)
@@ -45,12 +48,12 @@ public class JwtUtil {
 
             refreshTokenService.saveTokenInfo(loginUser.getId(), newRefreshToken, newAccessToken, remainingTTL);
 
-            if(loginUser.getLoginType().toString().equals("KAKAO")){
+            if(loginUser.getLoginType().toString().equals(KAKAO_LOGIN_TYPE)){
                 KakaoToken kakaoToken = kakaoTokenService.getByAccessToken(accessToken)
                         .orElseThrow();
 
                 kakaoTokenService.saveKakaoTokenInfo(loginUser.getId(), kakaoToken.getKakaoToken(), newAccessToken);
-            }else if(loginUser.getLoginType().toString().equals("NAVER")){
+            }else if(loginUser.getLoginType().toString().equals(NAVER_LOGIN_TYPE)){
                 NaverToken naverToken = naverTokenService.getByAccessToken(accessToken)
                         .orElseThrow();
 


### PR DESCRIPTION
AccessToken 재발급 안된다고 하시길래 검사할 겸 리팩토링도 진행해봤습니다.

1. 기존 재발급 메서드의 반환 값을 boolean으로 하고 true를 Controller에 반환할 경우, 
response header에 추가해놨던 "Authorization"에 해당하는 값(새 AccessToken)을 프론트에 넘겨줌
-> 재발급 메서드의 반환 값을 String(새 AccessToken String)을 Controller에 반환하고,
JwtResponse DTO를 통해 프론트로 넘겨주는 방식(즉 Login API와 아예 똑같은 방식)으로 변경했습니다.
- 전자의 경우도 Swagger로 했을 때 문제가 없긴 했는데, 뭔가 안된다고 하니 Login API랑 완전히 똑같은 방식으로
바꿨습니다. 해당 사항이 그나마 안 돌아갈 여지를 줄 수 있는 사항이었어서 수정을 했고, 바꾼 방식이 안되면 
제가 짠 코드선에선 진짜 뭐가 문제인지 알 수가 없는 상황입니다(네트워크 적인 문제 or 프론트 측 문제).

2. 에러 핸들링이나 짤짤한 리팩토링(간단한 로직 추가, 상수화 등) 진행 했습니다.