### PR TITLE
feat: 좋아요 카운트 코드 구현

### DIFF
--- a/src/main/java/com/elice/ustory/domain/like/LikeController.java
+++ b/src/main/java/com/elice/ustory/domain/like/LikeController.java
@@ -1,5 +1,6 @@
 package com.elice.ustory.domain.like;
 
+import com.elice.ustory.domain.like.dto.LikeCountResponse;
 import com.elice.ustory.domain.like.dto.LikeListResponse;
 import com.elice.ustory.domain.like.dto.LikeResponse;
 import com.elice.ustory.domain.paper.entity.Paper;
@@ -9,6 +10,7 @@ import com.elice.ustory.global.Validation.PageableValidation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -95,6 +97,22 @@ public class LikeController {
         boolean isLiked = likeService.isPaperLikedByUser(userId, paperId);
 
         return ResponseEntity.ok(new LikeResponse(isLiked));
+    }
+
+    @Operation(summary = "Like Count API",
+            description = "해당 페이퍼에서 좋아요의 총 갯수를 반환한다. <br>" +
+                    "countLike로 갯수를 알 수 있다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Ok", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LikeCountResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{paperId}/count")
+    public ResponseEntity<LikeCountResponse> countLiked(@PathVariable Long paperId) {
+
+        int count = likeService.countLikedById(paperId);
+
+        return ResponseEntity.ok(new LikeCountResponse(count));
     }
 
     @Operation(summary = "Delete Like API", description = "좋아요를 해제한다.")

--- a/src/main/java/com/elice/ustory/domain/like/LikeController.java
+++ b/src/main/java/com/elice/ustory/domain/like/LikeController.java
@@ -100,8 +100,8 @@ public class LikeController {
     }
 
     @Operation(summary = "Like Count API",
-            description = "해당 페이퍼에서 좋아요의 총 갯수를 반환한다. <br>" +
-                    "countLike로 갯수를 알 수 있다.")
+            description = "해당 페이퍼에서 좋아요의 총 개수를 반환한다. <br>" +
+                    "countLike로 개수를 알 수 있다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Ok", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LikeCountResponse.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),

--- a/src/main/java/com/elice/ustory/domain/like/LikeService.java
+++ b/src/main/java/com/elice/ustory/domain/like/LikeService.java
@@ -23,7 +23,6 @@ public class LikeService {
     private static final String NOT_FOUND_PAPER_MESSAGE = "%d: 해당하는 페이퍼가 존재하지 않습니다.";
     private static final String NOT_FOUND_LIKE_MESSAGE = "해당하는 좋아요가 존재하지 않습니다.";
     private static final String CONFLICT_LIKE_MESSAGE = "이미 좋아요로 지정되어 있습니다.";
-    private static final String MINUS_LIKE_MESSAGE = "%d: 현재 페이퍼의 좋아요에서 문제가 발생했습니다.(음수)";
 
     private final LikeRepository likeRepository;
     private final UserRepository userRepository;
@@ -67,19 +66,13 @@ public class LikeService {
         likeRepository.delete(like);
     }
 
-    /** 좋아요 총 갯수 반환 메서드 **/
+    /** 좋아요 총 개수 반환 메서드 **/
     public int countLikedById(Long paperId) {
 
         // 먼저 해당 페이퍼가 있는지 없는지 체크한 뒤, 페이퍼가 없다면 에러 반환
         Paper paper = paperRepository.findById(paperId)
                 .orElseThrow(() -> new NotFoundException(String.format(NOT_FOUND_PAPER_MESSAGE, paperId)));
 
-        Integer count = likeRepository.countLikeById(paperId);
-
-        if(count < 0) {
-            throw new InternalServerException(String.format(MINUS_LIKE_MESSAGE, paperId));
-        }
-
-        return count;
+        return likeRepository.countLikeById(paperId);
     }
 }

--- a/src/main/java/com/elice/ustory/domain/like/LikeService.java
+++ b/src/main/java/com/elice/ustory/domain/like/LikeService.java
@@ -7,6 +7,7 @@ import com.elice.ustory.domain.paper.repository.PaperRepository;
 import com.elice.ustory.domain.user.entity.Users;
 import com.elice.ustory.domain.user.repository.UserRepository;
 import com.elice.ustory.global.exception.model.ConflictException;
+import com.elice.ustory.global.exception.model.InternalServerException;
 import com.elice.ustory.global.exception.model.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +23,7 @@ public class LikeService {
     private static final String NOT_FOUND_PAPER_MESSAGE = "%d: 해당하는 페이퍼가 존재하지 않습니다.";
     private static final String NOT_FOUND_LIKE_MESSAGE = "해당하는 좋아요가 존재하지 않습니다.";
     private static final String CONFLICT_LIKE_MESSAGE = "이미 좋아요로 지정되어 있습니다.";
+    private static final String MINUS_LIKE_MESSAGE = "%d: 현재 페이퍼의 좋아요에서 문제가 발생했습니다.(음수)";
 
     private final LikeRepository likeRepository;
     private final UserRepository userRepository;
@@ -63,5 +65,21 @@ public class LikeService {
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_LIKE_MESSAGE));
 
         likeRepository.delete(like);
+    }
+
+    /** 좋아요 총 갯수 반환 메서드 **/
+    public int countLikedById(Long paperId) {
+
+        // 먼저 해당 페이퍼가 있는지 없는지 체크한 뒤, 페이퍼가 없다면 에러 반환
+        Paper paper = paperRepository.findById(paperId)
+                .orElseThrow(() -> new NotFoundException(String.format(NOT_FOUND_PAPER_MESSAGE, paperId)));
+
+        Integer count = likeRepository.countLikeById(paperId);
+
+        if(count < 0) {
+            throw new InternalServerException(String.format(MINUS_LIKE_MESSAGE, paperId));
+        }
+
+        return count;
     }
 }

--- a/src/main/java/com/elice/ustory/domain/like/dto/LikeCountResponse.java
+++ b/src/main/java/com/elice/ustory/domain/like/dto/LikeCountResponse.java
@@ -1,0 +1,14 @@
+package com.elice.ustory.domain.like.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class LikeCountResponse {
+
+    @Schema(description = "서비스 내에서 해당 페이퍼에 좋아요 총 갯수",  example = "정수 타입으로, 0 부터 시작")
+    private int countLike;
+
+}

--- a/src/main/java/com/elice/ustory/domain/like/dto/LikeCountResponse.java
+++ b/src/main/java/com/elice/ustory/domain/like/dto/LikeCountResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 public class LikeCountResponse {
 
-    @Schema(description = "서비스 내에서 해당 페이퍼에 좋아요 총 갯수",  example = "정수 타입으로, 0 부터 시작")
+    @Schema(description = "서비스 내에서 해당 페이퍼에 좋아요 총 개수",  example = "정수 타입으로, 0 부터 시작")
     private int countLike;
 
 }

--- a/src/main/java/com/elice/ustory/domain/like/repository/LikeQueryDslRepository.java
+++ b/src/main/java/com/elice/ustory/domain/like/repository/LikeQueryDslRepository.java
@@ -14,4 +14,6 @@ public interface LikeQueryDslRepository {
 
     /** userId에 해당하는 Bookmark 들의 Paper List 가져오기 */
     List<Paper> findLikesByUserId(Long userId, Pageable pageable);
+
+    Integer countLikeById(Long paperId);
 }

--- a/src/main/java/com/elice/ustory/domain/like/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/elice/ustory/domain/like/repository/LikeRepositoryImpl.java
@@ -38,4 +38,12 @@ public class LikeRepositoryImpl implements LikeQueryDslRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
     }
+
+    @Override
+    public Integer countLikeById(Long paperId) {
+        return queryFactory.select(like.count().intValue())
+                .from(like)
+                .where(like.paper.id.eq(paperId))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/elice/ustory/domain/paper/PaperController.java
+++ b/src/main/java/com/elice/ustory/domain/paper/PaperController.java
@@ -196,7 +196,7 @@ public class PaperController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "Count Write Paper By Specific User API", description = "특정 유저가 작성한 모든 페이퍼의 갯수를 불러온다.")
+    @Operation(summary = "Count Write Paper By Specific User API", description = "특정 유저가 작성한 모든 페이퍼의 개수를 불러온다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Ok", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PaperCountResponse.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),


### PR DESCRIPTION
해당 페이퍼의 좋아요 갯수를 반환해주는 API를 구현했습니다.

papers/{paperId}/count 를 엔드포인트로 잡았으며,
페이퍼 아이디를 통해, 해당 페이퍼에 좋아요 갯수를 카운트해서 반납합니다.