### PR TITLE
fix: 댓글을 불러올때, 생성날짜 오류

### DIFF
--- a/src/main/java/com/elice/ustory/domain/comment/dto/CommentListResponse.java
+++ b/src/main/java/com/elice/ustory/domain/comment/dto/CommentListResponse.java
@@ -41,7 +41,7 @@ public class CommentListResponse {
 //        this.userId = comment.getUser().getId();
         this.userNickname = comment.getUser().getNickname();
         this.profileImg = comment.getUser().getProfileImgUrl();
-        this.createdAt = LocalDate.now();
+        this.createdAt = comment.getCreatedAt().toLocalDate();
         this.isUpdatable = comment.getUser().getId() == userId ? 1 : 0;
     }
 }

--- a/src/main/java/com/elice/ustory/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/elice/ustory/domain/comment/dto/CommentResponse.java
@@ -36,6 +36,6 @@ public class CommentResponse {
 //        this.userId = comment.getUser().getId();
         this.userNickname = comment.getUser().getNickname();
         this.profileImg = comment.getUser().getProfileImgUrl();
-        this.createdAt = LocalDate.now();
+        this.createdAt = comment.getCreatedAt().toLocalDate();
     }
 }


### PR DESCRIPTION
댓글 Response에서 생성 시, 현재 시간으로 생성되게 되어있어서 페이지에서 현재 시간으로 댓글이 보여지고 있어서 수정했습니다.