### PR TITLE
fix:paperCount, 동시성 문제 해결

### DIFF
--- a/src/main/java/com/elice/ustory/domain/paper/service/PaperService.java
+++ b/src/main/java/com/elice/ustory/domain/paper/service/PaperService.java
@@ -222,14 +222,16 @@ public class PaperService {
         return paper;
     }
 
-    public Integer countPapersByWriterId(Long userId) {
+    public int countPapersByWriterId(Long userId) {
         List<Paper> findByWriterId = paperRepository.findByWriterId(userId);
-        for(Paper paper : findByWriterId) {
-            if (paper.isDeleted()) {
-                findByWriterId.remove(paper);
+        int count = 0;
+
+        for (Paper paper : findByWriterId) {
+            if (!paper.isDeleted()) {
+                count++;
             }
         }
-        return findByWriterId.size();
+        return count;
     }
 
     // 작성자를 제외한 멤버들에게 코멘트를 달아달라고 알림 전송, 트랜잭션?


### PR DESCRIPTION
마이페이지에 있는 자신이 작성한 페이퍼의 개수를 반환해주는 메서드를 수정했습니다.

이전 코드는 리스트의 특성상 동시성 문제가 발생하였고, 그로 인해서 개수를 따로 변수로 빼서 반환하는 방식으로
코드 수정 진행하였습니다.